### PR TITLE
Review spec version 0.3

### DIFF
--- a/SpxpProfileSpec-V03.md
+++ b/SpxpProfileSpec-V03.md
@@ -318,11 +318,11 @@ Example:
 ```
 	
 ## 11 Posts endpoint
-Social profiles can publish a stream of timestamped messages, named “posts”. Henceforth, the `timestamp` datatype is defined as follows:
+Social profiles can publish a stream of timestamped messages, named “posts”. Henceforth, the "timestamp" datatype is defined as follows:
 
 | Name | Type | Description |
 |---|---|---|
-| `timestamp` | String | A timestamp in the format “YYYY-MM-DD’T’hh:mm:ss.sss”, always in UTC. |
+| timestamp | String | A timestamp in the format “YYYY-MM-DD’T’hh:mm:ss.sss”, always in UTC. |
 
 If a social profile declares a `postsEndpoint` in the profile root document ([5](#5-social-profile-root-document)), then the server responds with the following JSON object:
 


### PR DESCRIPTION
[RENDERED](https://github.com/spxp/spxp-specs/blob/d998d6a8eee84bf5a0b31fc0696a2a96e03c0630/SpxpProfileSpec-V03.md)

My first read through in a while. Here is what I did:

- Improve formatting, e.g. by using code formatting for strings in code
- Add a definition for the `timestamp` data type in section 11 as it occurs a couple of times and was used twice without definition
- Add links to other sections of the document. This is especially true for the `septs` and `private` JSON keys in section 9.1 that were mentioned without introduction, as well as for the `AAD` mentions in section 9 and 12.
- Tried to make the connection procedure in section 16.1 a bit easier to understand by stating that certificate in these cases means the authorized signing key
- Minor rewording here and there

Here are my thoughts when I went through:
* Does it make sense to support multiple email addresses per profile?
* Does it make sense to have an additional coloumn in some tables called “part of signature” or similar with boolean values?
* Some objects allow free text fields. Do they support emojis in case the client is able to render it? Does JSON support line breaks within a "value"?
* Should the video type `preview` field need to support animated Gifs? Or size limited MP4s?
* The JSON member names of the profile root object are lower camel case. Should `seqts` and `createts` also be lower camel case, e.g. `seqTs` or `createTs`? 
* In chapter 11 it says for the `seqts` timestamp:
  > Probably assigned by the SPXP server when it received this post object.

  That sounds vague. Does that need to be further detailed?
* I like it that the _ephemeral connection establishment key pair_ is gone now and there is only a _ephemeral connection establishment key_ left 😉 