### PR TITLE
Change Request CR-001: ProfileRelocation

### DIFF
--- a/ChangeRequests/CR-001_ProfileRelocation.md
+++ b/ChangeRequests/CR-001_ProfileRelocation.md
@@ -1,5 +1,5 @@
 # CR-001 - Profile Relocation
-Final - Target SPXP 0.4
+Accepted - Target SPXP 0.4
 
 It has always been an early goal of this protocol to avoid user lock-in on specific applications or providers. The
 protocol intentionally gives the profile key precedence over the URI

--- a/ChangeRequests/README.md
+++ b/ChangeRequests/README.md
@@ -3,5 +3,5 @@ We try to organise the work on this protocol with change requests. The following
 
 | ID | Description | Target | State |
 |---|---|---|---|
-| [CR-001](./CR-001_ProfileRelocation.md) | Profile relocation | 0.4 | Draft |
+| [CR-001](./CR-001_ProfileRelocation.md) | Profile relocation | 0.4 | Accepted |
 | [CR-002](./CR-002_PublishToConnectedProfile.md) | Publishing to connected profiles | 0.4 | Draft |

--- a/SPXP-Spec.md
+++ b/SPXP-Spec.md
@@ -1196,10 +1196,9 @@ If a client discovers a signed post by a profile on a peer profile with a differ
 more recent creation date as the latest profile timestamp on record, then this is a good reason to believe that the
 known profile URI delivers stale information.
 
-It is possible that a malicious actor is copying the profile root document to a different URI and trying to trick
-clients into switching over to this URI. This can be used to prevent clients from receiving updates from the original
-profile. To prevent this, it is important that clients check the `profileLocation` and `timestamp` in the new profile
-root document.  
+A malicious actor might want to prevent clients from receiving updates from a profile. They could copy the profile
+root document to a different URI and try tricking clients into switching over to this URI. To prevent this, it is
+important that clients check the `profileLocation` and `timestamp` in the new profile root document.
 In case a profile has been relocated multiple times, the `timestamp` value also helps clients to identify the most
 recent profile location.
 


### PR DESCRIPTION
## Profile Relocation
It has always been an early goal of this protocol to avoid user lock-in on specific applications or providers. The protocol intentionally gives the profile key precedence over the URI ([see 1.3](https://github.com/spxp/spxp-specs/blob/v0.3/SPXP-Spec.md#13-unique-profile-identification)) to bind a profile to the cryptographic key rather than the URI. This degrades the profile provider to a mere publishing service which can be swapped for a different provider.

However, the current version 0.3 of SPXP does not provide a guided migration process or give enough hints for implementors how to discover the new profile URI of a relocated profile.

The original Change Request CR-001_ProfileRelocation can be found [here](https://github.com/spxp/spxp-specs/blob/master/ChangeRequests/CR-001_ProfileRelocation.md).