### PR TITLE
CR003 Comments and Reactions

### DIFF
--- a/ChangeRequests/CR-003_CommentsAndReactions.md
+++ b/ChangeRequests/CR-003_CommentsAndReactions.md
@@ -1,5 +1,5 @@
 # CR-003 - Comments and Reactions
-Draft - Target SPXP 0.4
+Accepted - Target SPXP 0.4
 
 It has always been the intention of SPXP to enable social engagement through comments and reactions between profile
 owners. Version 0.3 has already introduced the possibility for posts to have a different author signing the post with a

--- a/ChangeRequests/README.md
+++ b/ChangeRequests/README.md
@@ -5,4 +5,4 @@ We try to organise the work on this protocol with change requests. The following
 |---|---|---|---|
 | [CR-001](./CR-001_ProfileRelocation.md) | Profile relocation | 0.4 | Accepted |
 | [CR-002](./CR-002_PublishToConnectedProfile.md) | Publishing to connected profiles | 0.4 | Accepted |
-| [CR-003](./CR-003_CommentsAndReactions.md) | Comments and Reactions | 0.4 | Draft |
+| [CR-003](./CR-003_CommentsAndReactions.md) | Comments and Reactions | 0.4 | Accepted |


### PR DESCRIPTION
It has always been the intention of SPXP to enable social engagement through comments and reactions between profile owners. Version 0.3 has already introduced the possibility for posts to have a different author signing the post with a certificate. The most recent [CR-002](https://github.com/spxp/spxp-specs/blob/master/ChangeRequests/CR-002_PublishToConnectedProfile.md) then added a mechanism for profiles to receive contributions from various sources through a publishing endpoint.

What is yet missing are specialised post types for comments and reactions as well as a mechanism for these to reference other posts. This will be combined with more fine-grained grants to enable profile owners to selectively allow posting, commenting or reacting. We will also introduce a mechanism to govern these contributions on a per post level.