### PR TITLE
Add CORS recommendation for browser-based clients (section 2)

### DIFF
--- a/SPXP-Spec.md
+++ b/SPXP-Spec.md
@@ -29,7 +29,9 @@ profiles attest the identity of connected profiles.
 
 ## 2 Communication protocols
 Data is exchanged between participating clients and servers via HTTP, preferably over TLS (i.e. HTTPS). Clients and
-servers are encouraged to use the latest versions of these protocols, e.g. HTTP/2 and HTTP/3, and to prefer IPv6.
+servers are encouraged to use the latest versions of these protocols, e.g. HTTP/2 and HTTP/3, and to prefer IPv6.  
+SPXP servers SHOULD include the HTTP response header `Access-Control-Allow-Origin: *` on all SPXP endpoints. This
+allows browser-based clients to access SPXP profiles and endpoints directly without requiring a server-side proxy.
 
 ## 3 Transport encoding of structured data
 Data is encoded as JSON according to [RFC 7519 “The JavaScript Object Notation (JSON) Data Interchange


### PR DESCRIPTION
Closes #12

## Summary

Adds a SHOULD-level recommendation for SPXP servers to include the `Access-Control-Allow-Origin: *` HTTP response header on all endpoints.

## Motivation

Browser-based SPXP clients (e.g. web viewers, web UIs) cannot access SPXP endpoints cross-origin without CORS headers. Currently, such clients must route all requests through a server-side proxy — a significant barrier that contradicts the protocol's design goal of direct client-server communication.

Adding this as a SHOULD (not MUST) keeps existing server implementations valid while signalling best practice for new implementations and hosting providers.

## Changes

- **`SPXP-Spec.md`, section 2 (Communication protocols):** Added one sentence recommending `Access-Control-Allow-Origin: *` on all SPXP endpoints.